### PR TITLE
fix: d key does nothing when no chats are selected

### DIFF
--- a/model.go
+++ b/model.go
@@ -368,6 +368,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case "d":
+			if len(m.selected) == 0 && m.cursor < len(m.chats) {
+				m.selected[m.cursor] = true
+			}
 			if len(m.selected) > 0 {
 				m.confirmDelete = true
 			}
@@ -823,6 +826,12 @@ func (m model) updateGrouped(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "d":
+		if len(m.selected) == 0 && m.cursor < len(m.groupRows) {
+			row := m.groupRows[m.cursor]
+			if !row.isHeader {
+				m.selected[row.chatIdx] = true
+			}
+		}
 		if len(m.selected) > 0 {
 			m.confirmDelete = true
 		}


### PR DESCRIPTION
Pressing `d` with no chats selected silently did nothing, even when a chat was highlighted. This made the key appear broken.

Now pressing `d` on a highlighted chat auto-selects it and immediately shows the delete confirmation — consistent with how most list UIs behave.

Fixes #8